### PR TITLE
Revenge of the manifest

### DIFF
--- a/crates/wascc-host/Cargo.toml
+++ b/crates/wascc-host/Cargo.toml
@@ -27,6 +27,7 @@ libloading = "0.6.4"
 log = "0.4.11"
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"
+serde_yaml = "0.8.14"
 uuid = {version = "0.8", features  = ["serde", "v4"]}
 ring = "0.16.15"
 data-encoding = "2.3.0"
@@ -40,6 +41,7 @@ wascc-codec = "0.9.0"
 oci-distribution = "0.4.0"
 rand = "0.7.3"
 chrono = "0.4.19"
+envmnt = "0.8.4"
 
 wasm3-provider = { version = "0.0.2", optional = true}
 wasmtime-provider = { version = "0.0.2" , optional = true}

--- a/crates/wascc-host/Cargo.toml
+++ b/crates/wascc-host/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "0.3.0", features = ["rt"] }
 futures = "0.3.6"
 rmp-serde = "0.14.4"
 serde_bytes = "0.11.5"
-provider-archive ="0.1.0"
+provider-archive ="0.3.0"
 lazy_static = "1.4.0"
 wascc-codec = "0.9.0"
 oci-distribution = "0.4.0"

--- a/crates/wascc-host/src/actors/actor_host.rs
+++ b/crates/wascc-host/src/actors/actor_host.rs
@@ -1,5 +1,6 @@
 use crate::actors::WasccActor;
 use crate::control_plane::actorhost::{ControlPlane, PublishEvent};
+use crate::control_plane::events::TerminationReason;
 use crate::dispatch::{Invocation, InvocationResponse, WasccEntity};
 use crate::messagebus::{MessageBus, PutClaims, Subscribe, Unsubscribe};
 use crate::middleware::{run_actor_post_invoke, run_actor_pre_invoke, Middleware};
@@ -8,7 +9,6 @@ use actix::prelude::*;
 use futures::executor::block_on;
 use wapc::{WapcHost, WasiParams};
 use wascap::prelude::{Claims, KeyPair};
-use crate::control_plane::events::TerminationReason;
 
 pub(crate) struct ActorHost {
     guest_module: WapcHost,

--- a/crates/wascc-host/src/actors/actor_host.rs
+++ b/crates/wascc-host/src/actors/actor_host.rs
@@ -66,8 +66,7 @@ impl Actor for ActorHost {
 
     fn started(&mut self, ctx: &mut Self::Context) {
         info!("Actor {} started", &self.claims.subject);
-        println!("Actor {} started", &self.claims.subject);
-        //TODO: make this value configurable
+
         let entity = WasccEntity::Actor(self.claims.subject.to_string());
         let b = MessageBus::from_registry();
         let b2 = b.clone();
@@ -82,7 +81,7 @@ impl Actor for ActorHost {
         let c = self.claims.clone();
         let _ = block_on(async move {
             if let Err(e) = b2.send(PutClaims { claims: c }).await {
-                error!("Actor failed to subscribe to bus: {}", e);
+                error!("Actor failed to advertise claims to bus: {}", e);
                 ctx.stop();
             }
         });
@@ -100,7 +99,7 @@ impl Actor for ActorHost {
     }
 
     fn stopped(&mut self, ctx: &mut Self::Context) {
-        println!("Actor {} stopped", &self.claims.subject);
+        info!("Actor {} stopped", &self.claims.subject);
         let _ = block_on(async move {
             let cp = ControlPlane::from_registry();
             cp.send(PublishEvent {
@@ -122,7 +121,12 @@ impl Handler<Invocation> for ActorHost {
     /// middleware chain, perform the requested operation, and then perform the full
     /// post-exec middleware chain, assuming no errors indicate a pre-emptive halt
     fn handle(&mut self, msg: Invocation, ctx: &mut Self::Context) -> Self::Result {
-        println!("Actor being invoked");
+        trace!(
+            "Actor Invocation - From {} to {}: {}",
+            msg.origin.url(),
+            msg.target.url(),
+            msg.operation
+        );
 
         if let WasccEntity::Actor(ref target) = msg.target {
             if run_actor_pre_invoke(&msg, &self.mw_chain).is_err() {

--- a/crates/wascc-host/src/capability/binding_cache.rs
+++ b/crates/wascc-host/src/capability/binding_cache.rs
@@ -1,6 +1,6 @@
 use crate::Result;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use serde::{Serialize, Deserialize};
 
 /// When an an actor binds to a capability provider, it does so with a contract ID
 /// (e.g. 'wascc:messaging') and a binding name (e.g. `default`). The triplet of

--- a/crates/wascc-host/src/capability/extras.rs
+++ b/crates/wascc-host/src/capability/extras.rs
@@ -3,7 +3,9 @@
 // generating a guid, and generating a sequence number... things that a standalone
 // WASM module cannot do.
 
+use crate::generated::core::HealthResponse;
 use crate::generated::extras::{GeneratorRequest, GeneratorResult};
+use crate::messagebus::handlers::OP_HEALTH_REQUEST;
 use crate::VERSION;
 use std::error::Error;
 use std::sync::{Arc, RwLock};
@@ -19,8 +21,6 @@ use wascc_codec::capabilities::{
 };
 use wascc_codec::core::OP_BIND_ACTOR;
 use wascc_codec::{deserialize, serialize, SYSTEM_ACTOR};
-use crate::messagebus::handlers::OP_HEALTH_REQUEST;
-use crate::generated::core::HealthResponse;
 
 const REVISION: u32 = 3;
 
@@ -175,7 +175,7 @@ impl CapabilityProvider for ExtrasCapabilityProvider {
 fn healthy() -> Result<Vec<u8>, Box<dyn std::error::Error + Sync + Send>> {
     let hr = HealthResponse {
         message: "".to_string(),
-        healthy: true
+        healthy: true,
     };
     Ok(serialize(hr)?)
 }

--- a/crates/wascc-host/src/capability/native_host.rs
+++ b/crates/wascc-host/src/capability/native_host.rs
@@ -1,5 +1,6 @@
 use crate::capability::native::NativeCapability;
 use crate::control_plane::actorhost::{ControlPlane, PublishEvent};
+use crate::control_plane::events::TerminationReason;
 use crate::dispatch::{Invocation, InvocationResponse, ProviderDispatcher, WasccEntity};
 use crate::messagebus::{MessageBus, Subscribe, Unsubscribe};
 use crate::middleware::{run_capability_post_invoke, run_capability_pre_invoke, Middleware};
@@ -15,7 +16,6 @@ use wascap::prelude::KeyPair;
 use wascc_codec::capabilities::{
     CapabilityDescriptor, CapabilityProvider, OP_GET_CAPABILITY_DESCRIPTOR,
 };
-use crate::control_plane::events::TerminationReason;
 
 pub(crate) struct NativeCapabilityHost {
     cap: NativeCapability,
@@ -245,7 +245,7 @@ mod test {
             let claims = crate::capability::extras::get_claims();
             let cap = NativeCapability::from_instance(extras, Some("default".to_string()), claims)
                 .unwrap();
-            NativeCapabilityHost::new(Arc::new(cap), vec![], key)
+            NativeCapabilityHost::try_new(cap, vec![], key, None).unwrap()
         });
 
         let req = GeneratorRequest {

--- a/crates/wascc-host/src/capability/native_host.rs
+++ b/crates/wascc-host/src/capability/native_host.rs
@@ -152,8 +152,8 @@ impl Actor for NativeCapabilityHost {
     }
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {
-        println!(
-            "Provider stopped {} ({})",
+        info!(
+            "Provider stopped {} - {}",
             &self.cap.claims.subject, self.descriptor.name
         );
 
@@ -179,7 +179,11 @@ impl Handler<Invocation> for NativeCapabilityHost {
     /// the capability provider pre-invoke middleware, invokes the operation on the native
     /// plugin, then runs the provider post-invoke middleware.
     fn handle(&mut self, inv: Invocation, ctx: &mut Self::Context) -> Self::Result {
-        println!("Provider handling {}", inv.operation);
+        trace!(
+            "Provider {} handling {}",
+            self.cap.claims.subject,
+            inv.operation
+        );
         if let WasccEntity::Actor(ref s) = inv.origin {
             if let WasccEntity::Capability {
                 id,

--- a/crates/wascc-host/src/control_plane/events.rs
+++ b/crates/wascc-host/src/control_plane/events.rs
@@ -1,6 +1,6 @@
+use crate::generated::core::HealthResponse;
 use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
-use crate::generated::core::HealthResponse;
 use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
@@ -58,8 +58,8 @@ pub enum ControlEvent {
     Heartbeat {
         header: EventHeader,
         claims: Vec<wascap::jwt::Claims<wascap::jwt::Actor>>,
-        entities: HashMap<String, RunState>
-    }
+        entities: HashMap<String, RunState>,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -92,7 +92,9 @@ impl ControlEvent {
                 actor,
                 reason,
             },
-            ActorStarted { actor, image_ref, .. } => ActorStarted {
+            ActorStarted {
+                actor, image_ref, ..
+            } => ActorStarted {
                 header: new_header,
                 actor,
                 image_ref,
@@ -145,12 +147,13 @@ impl ControlEvent {
                 provider_id,
                 reason,
             },
-            Heartbeat { claims, entities, .. } =>
-                Heartbeat {
-                    header: new_header,
-                    claims,
-                    entities
-                }
+            Heartbeat {
+                claims, entities, ..
+            } => Heartbeat {
+                header: new_header,
+                claims,
+                entities,
+            },
         }
     }
 }

--- a/crates/wascc-host/src/dispatch.rs
+++ b/crates/wascc-host/src/dispatch.rs
@@ -278,7 +278,7 @@ impl WasccEntity {
     pub fn key(&self) -> String {
         match self {
             WasccEntity::Actor(pk) => pk.to_string(),
-            WasccEntity::Capability { id, .. } => id.to_string()
+            WasccEntity::Capability { id, .. } => id.to_string(),
         }
     }
 }

--- a/crates/wascc-host/src/lib.rs
+++ b/crates/wascc-host/src/lib.rs
@@ -7,6 +7,7 @@ mod errors;
 mod generated;
 mod host;
 mod host_controller;
+mod manifest;
 mod messagebus;
 mod middleware;
 mod oci;
@@ -19,6 +20,7 @@ pub use control_plane::events::{ControlEvent, EventHeader};
 pub use control_plane::{ControlInterface, ControlPlaneProvider};
 pub use dispatch::{BusDispatcher, Invocation, InvocationResponse, WasccEntity};
 pub use host::{Host, HostBuilder};
+pub use manifest::HostManifest;
 pub use messagebus::LatticeProvider;
 
 pub type Result<T> = ::std::result::Result<T, Box<dyn ::std::error::Error + Send + Sync>>;

--- a/crates/wascc-host/src/manifest.rs
+++ b/crates/wascc-host/src/manifest.rs
@@ -1,0 +1,265 @@
+use crate::host_controller::{StartActor, StartProvider};
+use crate::messagebus::AdvertiseBinding;
+use crate::oci::fetch_oci_bytes;
+use crate::NativeCapability;
+use provider_archive::ProviderArchive;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::{fs::File, io::Read, path::Path};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HostManifest {
+    #[serde(default)]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub labels: HashMap<String, String>,
+    pub actors: Vec<String>,
+    pub capabilities: Vec<Capability>,
+    pub bindings: Vec<BindingEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Capability {
+    pub image_ref: String,
+    pub binding_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BindingEntry {
+    pub actor: String,
+    pub contract_id: String,
+    pub provider_id: String,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub binding_name: Option<String>,
+    pub values: Option<HashMap<String, String>>,
+}
+
+impl HostManifest {
+    /// Creates an instance of a host manifest from a file path. The de-serialization
+    /// type will be chosen based on the file path extension, selecting YAML for .yaml
+    /// or .yml files, and JSON for all other file extensions. If the path has no extension, the
+    /// de-serialization type chosen will be YAML.
+    pub fn from_path(
+        path: impl AsRef<Path>,
+        expand_env: bool,
+    ) -> std::result::Result<HostManifest, Box<dyn std::error::Error + Send + Sync>> {
+        let mut contents = String::new();
+        let mut file = File::open(path.as_ref())?;
+        file.read_to_string(&mut contents)?;
+        if expand_env {
+            contents = Self::expand_env(&contents);
+        }
+        match path.as_ref().extension() {
+            Some(e) => {
+                let e = e.to_str().unwrap().to_lowercase(); // convert away from the FFI str
+                if e == "yaml" || e == "yml" {
+                    serde_yaml::from_str::<HostManifest>(&contents).map_err(|e| e.into())
+                } else {
+                    serde_json::from_str::<HostManifest>(&contents).map_err(|e| e.into())
+                }
+            }
+            None => serde_yaml::from_str::<HostManifest>(&contents).map_err(|e| e.into()),
+        }
+    }
+
+    fn expand_env(contents: &str) -> String {
+        let mut options = envmnt::ExpandOptions::new();
+        options.default_to_empty = false; // If environment variable not found, leave unexpanded.
+        options.expansion_type = Some(envmnt::ExpansionType::UnixBracketsWithDefaults); // ${VAR:DEFAULT}
+
+        envmnt::expand(contents, Some(options))
+    }
+}
+
+pub(crate) async fn generate_actor_start_messages(manifest: &HostManifest) -> Vec<StartActor> {
+    let mut v = Vec::new();
+    for actor_ref in &manifest.actors {
+        let p = Path::new(&actor_ref);
+        if p.exists() {
+            // read actor from disk
+            if let Ok(a) = crate::Actor::from_file(p) {
+                v.push(StartActor {
+                    image_ref: None,
+                    actor: a,
+                });
+            }
+        } else {
+            // load actor from OCI
+            if let Ok(a) = fetch_oci_bytes(&actor_ref)
+                .await
+                .and_then(|bytes| crate::Actor::from_slice(&bytes))
+            {
+                v.push(StartActor {
+                    image_ref: Some(actor_ref.to_string()),
+                    actor: a,
+                });
+            }
+        }
+    }
+    v
+}
+
+pub(crate) async fn generate_provider_start_messages(
+    manifest: &HostManifest,
+) -> Vec<StartProvider> {
+    use std::io::Read;
+
+    let mut v = Vec::new();
+    for cap in &manifest.capabilities {
+        let p = Path::new(&cap.image_ref);
+        if p.exists() {
+            // read PAR from disk
+            if let Ok(prov) = file_bytes(&p)
+                .and_then(|bytes| ProviderArchive::try_load(&bytes))
+                .and_then(|par| NativeCapability::from_archive(&par, cap.binding_name.clone()))
+            {
+                v.push(StartProvider {
+                    provider: prov,
+                    image_ref: None,
+                })
+            }
+        } else {
+            // read PAR from OCI
+            if let Ok(prov) = fetch_oci_bytes(&cap.image_ref)
+                .await
+                .and_then(|bytes| ProviderArchive::try_load(&bytes))
+                .and_then(|par| NativeCapability::from_archive(&par, cap.binding_name.clone()))
+            {
+                v.push(StartProvider {
+                    provider: prov,
+                    image_ref: Some(cap.image_ref.to_string()),
+                })
+            }
+        }
+    }
+
+    v
+}
+
+pub(crate) async fn generate_adv_binding_messages(
+    manifest: &HostManifest,
+) -> Vec<AdvertiseBinding> {
+    manifest
+        .bindings
+        .iter()
+        .map(|config| AdvertiseBinding {
+            contract_id: config.contract_id.to_string(),
+            actor: config.actor.to_string(),
+            binding_name: config
+                .binding_name
+                .as_ref()
+                .unwrap_or(&"default".to_string())
+                .to_string(),
+            provider_id: config.provider_id.to_string(),
+            values: config.values.as_ref().unwrap_or(&HashMap::new()).clone(),
+        })
+        .collect()
+}
+
+fn file_bytes(path: &Path) -> crate::Result<Vec<u8>> {
+    let mut f = File::open(path)?;
+    let mut bytes = Vec::new();
+    f.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod test {
+    use super::{BindingEntry, Capability};
+    use std::collections::HashMap;
+
+    #[test]
+    fn round_trip() {
+        let manifest = super::HostManifest {
+            labels: HashMap::new(),
+            actors: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            capabilities: vec![
+                Capability {
+                    image_ref: "one".to_string(),
+                    binding_name: Some("default".to_string()),
+                },
+                Capability {
+                    image_ref: "two".to_string(),
+                    binding_name: Some("default".to_string()),
+                },
+            ],
+            bindings: vec![BindingEntry {
+                actor: "a".to_string(),
+                contract_id: "wascc:one".to_string(),
+                provider_id: "Vxxxone".to_string(),
+                values: Some(gen_values()),
+                binding_name: None,
+            }],
+        };
+        let yaml = serde_yaml::to_string(&manifest).unwrap();
+        assert_eq!(yaml, "---\nactors:\n  - a\n  - b\n  - c\ncapabilities:\n  - image_ref: one\n    binding_name: default\n  - image_ref: two\n    binding_name: default\nbindings:\n  - actor: a\n    contract_id: \"wascc:one\"\n    provider_id: Vxxxone\n    values:\n      ROOT: /tmp");
+    }
+
+    #[test]
+    fn round_trip_with_labels() {
+        let manifest = super::HostManifest {
+            labels: {
+                let mut hm = HashMap::new();
+                hm.insert("test".to_string(), "value".to_string());
+                hm
+            },
+            actors: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            capabilities: vec![
+                Capability {
+                    image_ref: "one".to_string(),
+                    binding_name: Some("default".to_string()),
+                },
+                Capability {
+                    image_ref: "two".to_string(),
+                    binding_name: Some("default".to_string()),
+                },
+            ],
+            bindings: vec![BindingEntry {
+                actor: "a".to_string(),
+                contract_id: "wascc:one".to_string(),
+                provider_id: "VxxxxONE".to_string(),
+                values: Some(gen_values()),
+                binding_name: Some("default".to_string()),
+            }],
+        };
+        let yaml = serde_yaml::to_string(&manifest).unwrap();
+        assert_eq!(yaml, "---\nlabels:\n  test: value\nactors:\n  - a\n  - b\n  - c\ncapabilities:\n  - image_ref: one\n    binding_name: default\n  - image_ref: two\n    binding_name: default\nbindings:\n  - actor: a\n    contract_id: \"wascc:one\"\n    provider_id: VxxxxONE\n    binding_name: default\n    values:\n      ROOT: /tmp");
+    }
+
+    #[test]
+    fn env_expansion() {
+        let values = vec![
+            "echo Test",
+            "echo $TEST_EXPAND_ENV_TEMP",
+            "echo ${TEST_EXPAND_ENV_TEMP}",
+            "echo ${TEST_EXPAND_ENV_TMP}",
+            "echo ${TEST_EXPAND_ENV_TEMP:/etc}",
+            "echo ${TEST_EXPAND_ENV_TMP:/etc}",
+        ];
+        let expected = vec![
+            "echo Test",
+            "echo $TEST_EXPAND_ENV_TEMP",
+            "echo /tmp",
+            "echo ${TEST_EXPAND_ENV_TMP}",
+            "echo /tmp",
+            "echo /etc",
+        ];
+
+        envmnt::set("TEST_EXPAND_ENV_TEMP", "/tmp");
+        for (got, expected) in values
+            .iter()
+            .map(|v| super::HostManifest::expand_env(v))
+            .zip(expected.iter())
+        {
+            assert_eq!(*expected, got);
+        }
+        envmnt::remove("TEST_EXPAND_ENV_TEMP");
+    }
+
+    fn gen_values() -> HashMap<String, String> {
+        let mut hm = HashMap::new();
+        hm.insert("ROOT".to_string(), "/tmp".to_string());
+
+        hm
+    }
+}

--- a/crates/wascc-host/src/messagebus/hb.rs
+++ b/crates/wascc-host/src/messagebus/hb.rs
@@ -1,15 +1,15 @@
 use super::MessageBus;
-use actix::prelude::*;
-use std::time::Duration;
-use crate::{ControlEvent, WasccEntity, Invocation, SYSTEM_ACTOR};
-use std::collections::HashMap;
-use wascap::prelude::KeyPair;
-use crate::control_plane::events::RunState;
-use crate::messagebus::handlers::OP_HEALTH_REQUEST;
-use crate::generated::core::{serialize, HealthRequest, HealthResponse, deserialize};
-use crate::Result;
-use futures::executor::block_on;
 use crate::control_plane::actorhost::{ControlPlane, PublishEvent};
+use crate::control_plane::events::RunState;
+use crate::generated::core::{deserialize, serialize, HealthRequest, HealthResponse};
+use crate::messagebus::handlers::OP_HEALTH_REQUEST;
+use crate::Result;
+use crate::{ControlEvent, Invocation, WasccEntity, SYSTEM_ACTOR};
+use actix::prelude::*;
+use futures::executor::block_on;
+use std::collections::HashMap;
+use std::time::Duration;
+use wascap::prelude::KeyPair;
 
 const HEARTBEAT_INTERVAL_ENV_VAR: &str = "HEARTBEAT_INTERVAL_S";
 const DEFAULT_HEARTBEAT_INTERVAL: u16 = 30;
@@ -19,37 +19,48 @@ impl MessageBus {
     pub(crate) fn hb(&self, ctx: &mut Context<Self>) {
         println!("HB");
         let interval = hb_duration();
-        ctx.run_interval(interval, | act, ctx | {
+        ctx.run_interval(interval, |act, ctx| {
             let claims = act.claims_cache.values().cloned().collect();
             let subs = act.subscribers.clone();
             let entities: Vec<(_, _)> = subs.into_iter().collect();
             let seed = act.key.as_ref().unwrap().seed().unwrap();
 
-            ctx.wait(async move {
-                let evt = generate_heartbeat_event(entities, claims, seed).await;
-                let cp = ControlPlane::from_registry();
-                cp.do_send(PublishEvent{
-                    event: evt
-                });
-            }.into_actor(act));
+            ctx.wait(
+                async move {
+                    let evt = generate_heartbeat_event(entities, claims, seed).await;
+                    let cp = ControlPlane::from_registry();
+                    cp.do_send(PublishEvent { event: evt });
+                }
+                .into_actor(act),
+            );
         });
     }
 }
 
-async fn generate_heartbeat_event(entities: Vec<(WasccEntity, Recipient<Invocation>)>, claims: Vec<wascap::jwt::Claims<wascap::jwt::Actor>>, seed: String) -> ControlEvent {
+async fn generate_heartbeat_event(
+    entities: Vec<(WasccEntity, Recipient<Invocation>)>,
+    claims: Vec<wascap::jwt::Claims<wascap::jwt::Actor>>,
+    seed: String,
+) -> ControlEvent {
     ControlEvent::Heartbeat {
         header: Default::default(),
         claims: claims,
-        entities: healthping_subscribers(&entities, seed).await
+        entities: healthping_subscribers(&entities, seed).await,
     }
 }
 
-async fn healthping_subscribers(subs: &[(WasccEntity, Recipient<Invocation>)], seed: String) -> HashMap<String, RunState> {
+async fn healthping_subscribers(
+    subs: &[(WasccEntity, Recipient<Invocation>)],
+    seed: String,
+) -> HashMap<String, RunState> {
     let key = KeyPair::from_seed(&seed).unwrap();
     let mut hm = HashMap::new();
     for (subscriber, recipient) in subs {
         let ping = generate_ping(subscriber, &key);
-        let pong = recipient.send(ping).timeout(Duration::from_millis(PING_TIMEOUT_MS)).await;
+        let pong = recipient
+            .send(ping)
+            .timeout(Duration::from_millis(PING_TIMEOUT_MS))
+            .await;
         match pong {
             Ok(ir) => {
                 let hr: Result<HealthResponse> = deserialize(&ir.msg);
@@ -60,14 +71,25 @@ async fn healthping_subscribers(subs: &[(WasccEntity, Recipient<Invocation>)], s
                         } else {
                             hm.insert(subscriber.key(), RunState::Unhealthy(hr.message));
                         }
-                    },
+                    }
                     Err(e) => {
-                        hm.insert(subscriber.key(), RunState::Unhealthy("Failed to de-serialize health check response from target".to_string()));
+                        hm.insert(
+                            subscriber.key(),
+                            RunState::Unhealthy(
+                                "Failed to de-serialize health check response from target"
+                                    .to_string(),
+                            ),
+                        );
                     }
                 }
-            },
+            }
             Err(e) => {
-                hm.insert(subscriber.key(), RunState::Unhealthy("No successful health check response from target".to_string()));
+                hm.insert(
+                    subscriber.key(),
+                    RunState::Unhealthy(
+                        "No successful health check response from target".to_string(),
+                    ),
+                );
             }
         }
     }
@@ -80,19 +102,13 @@ fn generate_ping(target: &WasccEntity, key: &KeyPair) -> Invocation {
         WasccEntity::Actor(SYSTEM_ACTOR.to_string()),
         target.clone(),
         OP_HEALTH_REQUEST,
-        serialize(&HealthRequest{
-            placeholder: true
-        }).unwrap()
+        serialize(&HealthRequest { placeholder: true }).unwrap(),
     )
 }
 
 fn hb_duration() -> Duration {
     match std::env::var(HEARTBEAT_INTERVAL_ENV_VAR) {
-        Ok(s) => {
-            Duration::from_secs(s.parse().unwrap_or(DEFAULT_HEARTBEAT_INTERVAL as u64))
-        },
-        Err(_) => {
-            Duration::from_secs(DEFAULT_HEARTBEAT_INTERVAL as u64)
-        }
+        Ok(s) => Duration::from_secs(s.parse().unwrap_or(DEFAULT_HEARTBEAT_INTERVAL as u64)),
+        Err(_) => Duration::from_secs(DEFAULT_HEARTBEAT_INTERVAL as u64),
     }
 }

--- a/crates/wascc-host/src/messagebus/mod.rs
+++ b/crates/wascc-host/src/messagebus/mod.rs
@@ -1,16 +1,16 @@
-use std::collections::HashMap;
-use crate::capability::binding_cache::BindingCache;
-use crate::{WasccEntity, Invocation, BusDispatcher, InvocationResponse};
-use actix::prelude::*;
-use wascap::prelude::{Claims, KeyPair};
 use crate::auth::Authorizer;
-use actix::dev::{MessageResponse, ResponseChannel};
+use crate::capability::binding_cache::BindingCache;
 use crate::Result;
+use crate::{BusDispatcher, Invocation, InvocationResponse, WasccEntity};
+use actix::dev::{MessageResponse, ResponseChannel};
+use actix::prelude::*;
+use std::collections::HashMap;
+use wascap::prelude::{Claims, KeyPair};
 
 pub use handlers::OP_BIND_ACTOR;
 pub(crate) mod handlers;
-mod utils;
 mod hb;
+mod utils;
 
 pub trait LatticeProvider: Sync + Send {
     fn init(&mut self, dispatcher: BusDispatcher);
@@ -28,8 +28,6 @@ pub trait LatticeProvider: Sync + Send {
     ) -> Result<()>;
     fn advertise_claims(&self, claims: Claims<wascap::jwt::Actor>) -> Result<()>;
 }
-
-
 
 #[derive(Default)]
 pub(crate) struct MessageBus {
@@ -54,9 +52,9 @@ pub struct QueryResponse {
 }
 
 impl<A, M> MessageResponse<A, M> for QueryResponse
-    where
-        A: Actor,
-        M: Message<Result = QueryResponse>,
+where
+    A: Actor,
+    M: Message<Result = QueryResponse>,
 {
     fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
         if let Some(tx) = tx {
@@ -128,9 +126,9 @@ pub struct FindBindingsResponse {
 }
 
 impl<A, M> MessageResponse<A, M> for FindBindingsResponse
-    where
-        A: Actor,
-        M: Message<Result = FindBindingsResponse>,
+where
+    A: Actor,
+    M: Message<Result = FindBindingsResponse>,
 {
     fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
         if let Some(tx) = tx {

--- a/crates/wascc-host/src/messagebus/utils.rs
+++ b/crates/wascc-host/src/messagebus/utils.rs
@@ -1,8 +1,8 @@
-use actix::prelude::*;
-use crate::messagebus::{LatticeProvider, AdvertiseBinding};
-use crate::{Invocation, InvocationResponse, WasccEntity, SYSTEM_ACTOR};
-use wascap::prelude::KeyPair;
 use crate::messagebus::OP_BIND_ACTOR;
+use crate::messagebus::{AdvertiseBinding, LatticeProvider};
+use crate::{Invocation, InvocationResponse, WasccEntity, SYSTEM_ACTOR};
+use actix::prelude::*;
+use wascap::prelude::KeyPair;
 
 pub(crate) fn do_rpc(l: &Box<dyn LatticeProvider>, inv: &Invocation) -> InvocationResponse {
     match l.rpc(&inv) {


### PR DESCRIPTION
Putting the manifest feature back into wascc host. The new manifest is not backwards compatible with the old one because new binding require the provider ID, etc.