### PR TITLE
Block the use of `latest` OCI images by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ rmp-serde = "0.14.4"
 serde = {version = "1.0.117", features = ["derive"] }
 serde_bytes = "0.11.5"
 serde_json = "1.0.59"
-provider-archive = "0.1.2"
+provider-archive = "0.3.0"
 redis = "0.17.0"
 reqwest = { version = "0.10"}
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/crates/wascc-host/src/actors/actor_host.rs
+++ b/crates/wascc-host/src/actors/actor_host.rs
@@ -1,5 +1,5 @@
 use crate::actors::WasccActor;
-use crate::control_plane::actorhost::{ControlPlane, PublishEvent};
+use crate::control_plane::cpactor::{ControlPlane, PublishEvent};
 use crate::control_plane::events::TerminationReason;
 use crate::dispatch::{Invocation, InvocationResponse, WasccEntity};
 use crate::messagebus::{MessageBus, PutClaims, Subscribe, Unsubscribe};

--- a/crates/wascc-host/src/capability/native_host.rs
+++ b/crates/wascc-host/src/capability/native_host.rs
@@ -1,5 +1,5 @@
 use crate::capability::native::NativeCapability;
-use crate::control_plane::actorhost::{ControlPlane, PublishEvent};
+use crate::control_plane::cpactor::{ControlPlane, PublishEvent};
 use crate::control_plane::events::TerminationReason;
 use crate::dispatch::{Invocation, InvocationResponse, ProviderDispatcher, WasccEntity};
 use crate::messagebus::{MessageBus, Subscribe, Unsubscribe};

--- a/crates/wascc-host/src/control_plane/mod.rs
+++ b/crates/wascc-host/src/control_plane/mod.rs
@@ -1,11 +1,11 @@
-use crate::control_plane::actorhost::ControlPlane;
+use crate::control_plane::cpactor::ControlPlane;
 use crate::control_plane::events::ControlEvent;
 use crate::messagebus::MessageBus;
 use crate::Result;
 use actix::Addr;
 use std::collections::HashMap;
 
-pub(crate) mod actorhost;
+pub(crate) mod cpactor;
 pub mod events;
 
 /// A control plane provider is responsible for managing whatever endpoint (or endpoints) is

--- a/crates/wascc-host/src/host_controller.rs
+++ b/crates/wascc-host/src/host_controller.rs
@@ -2,7 +2,7 @@ use crate::actors::{ActorHost, WasccActor};
 use crate::auth::Authorizer;
 use crate::capability::extras::ExtrasCapabilityProvider;
 use crate::capability::native_host::{NativeCapabilityHost, NativeCapabilityHostBuilder};
-use crate::control_plane::actorhost::ControlPlane;
+use crate::control_plane::cpactor::ControlPlane;
 use crate::dispatch::Invocation;
 use crate::messagebus::{
     AdvertiseBinding, FindBindings, MessageBus, SetAuthorizer, SetKey, Unsubscribe, OP_BIND_ACTOR,

--- a/crates/wascc-host/src/manifest.rs
+++ b/crates/wascc-host/src/manifest.rs
@@ -71,7 +71,10 @@ impl HostManifest {
     }
 }
 
-pub(crate) async fn generate_actor_start_messages(manifest: &HostManifest) -> Vec<StartActor> {
+pub(crate) async fn generate_actor_start_messages(
+    manifest: &HostManifest,
+    allow_latest: bool,
+) -> Vec<StartActor> {
     let mut v = Vec::new();
     for actor_ref in &manifest.actors {
         let p = Path::new(&actor_ref);
@@ -85,7 +88,7 @@ pub(crate) async fn generate_actor_start_messages(manifest: &HostManifest) -> Ve
             }
         } else {
             // load actor from OCI
-            if let Ok(a) = fetch_oci_bytes(&actor_ref)
+            if let Ok(a) = fetch_oci_bytes(&actor_ref, allow_latest)
                 .await
                 .and_then(|bytes| crate::Actor::from_slice(&bytes))
             {
@@ -101,6 +104,7 @@ pub(crate) async fn generate_actor_start_messages(manifest: &HostManifest) -> Ve
 
 pub(crate) async fn generate_provider_start_messages(
     manifest: &HostManifest,
+    allow_latest: bool,
 ) -> Vec<StartProvider> {
     use std::io::Read;
 
@@ -120,7 +124,7 @@ pub(crate) async fn generate_provider_start_messages(
             }
         } else {
             // read PAR from OCI
-            if let Ok(prov) = fetch_oci_bytes(&cap.image_ref)
+            if let Ok(prov) = fetch_oci_bytes(&cap.image_ref, allow_latest)
                 .await
                 .and_then(|bytes| ProviderArchive::try_load(&bytes))
                 .and_then(|par| NativeCapability::from_archive(&par, cap.binding_name.clone()))

--- a/crates/wascc-host/src/messagebus/hb.rs
+++ b/crates/wascc-host/src/messagebus/hb.rs
@@ -1,5 +1,5 @@
 use super::MessageBus;
-use crate::control_plane::actorhost::{ControlPlane, PublishEvent};
+use crate::control_plane::cpactor::{ControlPlane, PublishEvent};
 use crate::control_plane::events::RunState;
 use crate::generated::core::{deserialize, serialize, HealthRequest, HealthResponse};
 use crate::messagebus::handlers::OP_HEALTH_REQUEST;

--- a/crates/wascc-host/src/oci.rs
+++ b/crates/wascc-host/src/oci.rs
@@ -7,7 +7,8 @@ pub(crate) const OCI_VAR_PASSWORD: &str = "OCI_REGISTRY_PASSWORD";
 
 pub(crate) async fn fetch_oci_bytes(img: &str, allow_latest: bool) -> Result<Vec<u8>> {
     if !allow_latest && img.ends_with(":latest") {
-        return Err("Fetching mutable images tagged 'latest' is prohibited".into());
+        return Err(
+            "Fetching images tagged 'latest' is currently prohibited in this host. This option can be overridden".into());
     }
     let cfg = oci_distribution::client::ClientConfig::default();
     let mut c = oci_distribution::Client::new(cfg);


### PR DESCRIPTION
Firstly, there's now a pattern established for getting parameters from the host builder to the control plane actor, and there are some "unused" variables like `max_actors` and `max_providers` that are there as placeholders to make it fairly obvious how to add more tuning / configuration parameters to the control plane.

Secondly, the control plane itself isn't doing any enforcement of the `allow_latest` flag because .. .well, the CP isn't implemented yet ;) If you want to know where it _will_ be, check out the placeholder functions on the `ControlInterface` struct, which is an object handed to control plane implementations (e.g. our NATS / lattice CP).

The limited enforcement of the "allow latest" flag that _is_ in this host is from the host functions that add/load actors and providers. If  the image reference ends with `:latest` and this flag is _false_, then an attempt to download the bytes will return an error, which then will propogate out to whatever consumer triggered that download (which should ultimately include the soon-to-be-implemented control interface).