### PR TITLE
Initial refactor for 'no fail' actor start

### DIFF
--- a/crates/wascc-host/src/actors/actor_host.rs
+++ b/crates/wascc-host/src/actors/actor_host.rs
@@ -113,7 +113,7 @@ impl Handler<Initialize> for ActorHost {
                     actor.token.claims.subject
                 );
                 ctx.stop();
-                Err("Failed to create a raw WebASsembly host".into())
+                Err("Failed to create a raw WebAssembly host".into())
             }
         }
     }

--- a/crates/wascc-host/src/actors/actor_host.rs
+++ b/crates/wascc-host/src/actors/actor_host.rs
@@ -74,7 +74,7 @@ impl Handler<Initialize> for ActorHost {
                     })
                     .await
                 });
-                let pc = PutClaims{ claims: c.clone() };
+                let pc = PutClaims { claims: c.clone() };
                 let r = block_on(async move {
                     if let Err(e) = b2.send(pc).await {
                         error!("Actor failed to advertise claims to bus: {}", e);
@@ -89,15 +89,13 @@ impl Handler<Initialize> for ActorHost {
                 }
                 let pe = PublishEvent {
                     event: ControlEvent::ActorStarted {
-                        header: Default::default(),
                         actor: c.subject.to_string(),
                         image_ref: msg.image_ref.clone(),
                     },
                 };
                 let _ = block_on(async move {
                     let cp = ControlPlane::from_registry();
-                    cp.send(pe)
-                    .await
+                    cp.send(pe).await
                 });
                 self.state = Some(State {
                     guest_module: g,
@@ -136,7 +134,6 @@ impl Actor for ActorHost {
             let cp = ControlPlane::from_registry();
             cp.send(PublishEvent {
                 event: ControlEvent::ActorStopped {
-                    header: Default::default(),
                     actor: state.claims.subject.to_string(),
                     reason: TerminationReason::Requested,
                 },

--- a/crates/wascc-host/src/actors/mod.rs
+++ b/crates/wascc-host/src/actors/mod.rs
@@ -1,5 +1,5 @@
 mod actor_host;
 mod wascc_actor;
 
-pub(crate) use actor_host::ActorHost;
+pub(crate) use actor_host::{ActorHost, Initialize};
 pub(crate) use wascc_actor::WasccActor;

--- a/crates/wascc-host/src/capability/native_host.rs
+++ b/crates/wascc-host/src/capability/native_host.rs
@@ -17,55 +17,257 @@ use wascc_codec::capabilities::{
     CapabilityDescriptor, CapabilityProvider, OP_GET_CAPABILITY_DESCRIPTOR,
 };
 
-#[derive(Clone)]
-pub(crate) struct NativeCapabilityHostBuilder {
-    cap: NativeCapability,
-    mw_chain: Vec<Box<dyn Middleware>>,
-    image_ref: Option<String>,
-    plugin: Box<dyn CapabilityProvider + 'static>,
-    library: Arc<Option<Library>>,
-    descriptor: CapabilityDescriptor,
+#[derive(Message)]
+#[rtype(result = "Result<WasccEntity>")]
+pub(crate) struct Initialize {
+    pub cap: NativeCapability,
+    pub mw_chain: Vec<Box<dyn Middleware>>,
+    pub seed: String,
+    pub image_ref: Option<String>,
 }
 
-impl NativeCapabilityHostBuilder {
-    pub fn try_new(
-        cap: NativeCapability,
-        mw_chain: Vec<Box<dyn Middleware>>,
-        image_ref: Option<String>,
-    ) -> Result<Self> {
-        let (library, plugin) = extrude(&cap)?;
-        let descriptor = get_descriptor(&plugin)?;
-        Ok(NativeCapabilityHostBuilder {
-            cap,
-            mw_chain,
-            plugin,
-            image_ref,
-            library: Arc::new(library),
-            descriptor,
-        })
+struct State {
+    cap: NativeCapability,
+    mw_chain: Vec<Box<dyn Middleware>>,
+    kp: KeyPair,
+    library: Option<Library>,
+    plugin: Box<dyn CapabilityProvider + 'static>,
+    descriptor: CapabilityDescriptor,
+    image_ref: Option<String>,
+}
+
+pub(crate) struct NativeCapabilityHost {
+    state: Option<State>,
+}
+
+impl NativeCapabilityHost {
+    pub fn new() -> Self {
+        NativeCapabilityHost { state: None }
+    }
+}
+
+impl Actor for NativeCapabilityHost {
+    type Context = SyncContext<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        info!("Native provider host started");
     }
 
-    pub fn build(self, kp: KeyPair) -> NativeCapabilityHost {
-        NativeCapabilityHost {
-            library: self.library,
-            plugin: self.plugin,
-            cap: self.cap,
-            mw_chain: self.mw_chain,
-            kp,
-            descriptor: self.descriptor,
-            image_ref: self.image_ref,
+    fn stopped(&mut self, _ctx: &mut Self::Context) {
+        let state = self.state.as_ref().unwrap();
+        info!(
+            "Provider stopped {} - {}",
+            &state.cap.claims.subject, &state.descriptor.name
+        );
+
+        let cp = ControlPlane::from_registry();
+        cp.do_send(PublishEvent {
+            event: ControlEvent::ProviderStopped {
+                header: Default::default(),
+                binding_name: state.cap.binding_name.to_string(),
+                provider_id: state.cap.claims.subject.to_string(),
+                contract_id: state.descriptor.id.to_string(),
+                reason: TerminationReason::Requested,
+            },
+        });
+        state.plugin.stop(); // Tell the provider to clean up, dispose of resources, stop threads, etc
+    }
+}
+
+impl Handler<Initialize> for NativeCapabilityHost {
+    type Result = Result<WasccEntity>;
+
+    fn handle(&mut self, msg: Initialize, ctx: &mut Self::Context) -> Self::Result {
+        let (library, plugin) = match extrude(&msg.cap) {
+            Ok((l, r)) => (l, r),
+            Err(e) => {
+                error!("Failed to extract plugin from provider: {}", e);
+                ctx.stop();
+                return Err("Failed to extract plugin from provider".into());
+            }
+        };
+        let descriptor = match get_descriptor(&plugin) {
+            Ok(d) => d,
+            Err(e) => {
+                error!("Failed to get descriptor from provider: {}", e);
+                ctx.stop();
+                return Err("Failed to get descriptor from provider".into());
+            }
+        };
+
+        self.state = Some(State {
+            cap: msg.cap,
+            mw_chain: msg.mw_chain,
+            kp: KeyPair::from_seed(&msg.seed)?,
+            library,
+            plugin,
+            descriptor,
+            image_ref: msg.image_ref,
+        });
+        let state = self.state.as_ref().unwrap();
+
+        let b = MessageBus::from_registry();
+        let entity = WasccEntity::Capability {
+            id: state.cap.claims.subject.to_string(),
+            contract_id: state.descriptor.id.to_string(),
+            binding: state.cap.binding_name.to_string(),
+        };
+
+        let nativedispatch = ProviderDispatcher::new(
+            b.clone().recipient(),
+            KeyPair::from_seed(&state.kp.seed().unwrap()).unwrap(),
+            entity.clone(),
+        );
+        if let Err(e) = state.plugin.configure_dispatch(Box::new(nativedispatch)) {
+            error!(
+                "Failed to configure provider dispatcher: {}, provider stopping.",
+                e
+            );
+            ctx.stop();
+            return Err(e);
+        }
+        let url = entity.url().to_string();
+        let submsg = Subscribe {
+            interest: entity.clone(),
+            subscriber: ctx.address().recipient(),
+        };
+        let _ = block_on(async move {
+            if let Err(e) = b.send(submsg).await {
+                error!(
+                    "Native capability provider failed to subscribe to bus: {}",
+                    e
+                );
+                ctx.stop();
+            }
+        });
+        let cp = ControlPlane::from_registry();
+        cp.do_send(PublishEvent {
+            event: ControlEvent::ProviderStarted {
+                header: Default::default(),
+                binding_name: state.cap.binding_name.to_string(),
+                provider_id: state.cap.claims.subject.to_string(),
+                contract_id: state.descriptor.id.to_string(),
+                image_ref: state.image_ref.clone(),
+            },
+        });
+        info!("Native Capability Provider '{}' ready", url);
+
+        Ok(entity)
+    }
+}
+
+impl Handler<Invocation> for NativeCapabilityHost {
+    type Result = InvocationResponse;
+
+    /// Receives an invocation from any source, validating the anti-forgery token
+    /// and that the destination matches this process. If those checks pass, runs
+    /// the capability provider pre-invoke middleware, invokes the operation on the native
+    /// plugin, then runs the provider post-invoke middleware.
+    fn handle(&mut self, inv: Invocation, ctx: &mut Self::Context) -> Self::Result {
+        let state = self.state.as_ref().unwrap();
+        trace!(
+            "Provider {} handling {}",
+            state.cap.claims.subject,
+            inv.operation
+        );
+        if let WasccEntity::Actor(ref s) = inv.origin {
+            if let WasccEntity::Capability {
+                id,
+                contract_id,
+                binding,
+            } = &inv.target
+            {
+                if id != &state.cap.id() {
+                    return InvocationResponse::error(
+                        &inv,
+                        "Invocation target ID did not match provider ID",
+                    );
+                }
+                if let Err(e) = run_capability_pre_invoke(&inv, &state.mw_chain) {
+                    return InvocationResponse::error(
+                        &inv,
+                        &format!("Capability middleware pre-invoke failure: {}", e),
+                    );
+                }
+
+                match state.plugin.handle_call(&s, &inv.operation, &inv.msg) {
+                    Ok(msg) => {
+                        let ir = InvocationResponse::success(&inv, msg);
+                        match run_capability_post_invoke(ir, &state.mw_chain) {
+                            Ok(r) => r,
+                            Err(e) => InvocationResponse::error(
+                                &inv,
+                                &format!("Capability middleware post-invoke failure: {}", e),
+                            ),
+                        }
+                    }
+                    Err(e) => InvocationResponse::error(&inv, &format!("{}", e)),
+                }
+            } else {
+                InvocationResponse::error(&inv, "Invocation sent to the wrong target")
+            }
+        } else {
+            InvocationResponse::error(&inv, "Attempt to invoke capability from non-actor origin")
         }
     }
 }
 
-pub(crate) struct NativeCapabilityHost {
-    cap: NativeCapability,
-    mw_chain: Vec<Box<dyn Middleware>>,
-    kp: KeyPair,
-    library: Arc<Option<Library>>,
-    plugin: Box<dyn CapabilityProvider + 'static>,
-    descriptor: CapabilityDescriptor,
-    image_ref: Option<String>,
+#[cfg(test)]
+mod test {
+    use crate::capability::extras::{ExtrasCapabilityProvider, OP_REQUEST_GUID};
+    use crate::capability::native::NativeCapability;
+    use crate::capability::native_host::NativeCapabilityHost;
+    use crate::dispatch::{Invocation, InvocationResponse, WasccEntity};
+    use crate::generated::extras::{GeneratorRequest, GeneratorResult};
+    use crate::Result;
+    use crate::SYSTEM_ACTOR;
+    use actix::prelude::*;
+    use std::sync::Arc;
+    use wascap::prelude::KeyPair;
+
+    #[actix_rt::test]
+    async fn test_extras_actor() {
+        let kp = KeyPair::new_server();
+        let seed = kp.seed().unwrap();
+        let key = KeyPair::from_seed(&seed).unwrap();
+        let extras = ExtrasCapabilityProvider::default();
+        let claims = crate::capability::extras::get_claims();
+        let cap = NativeCapability::from_instance(extras, Some("default".to_string()), claims)
+            .unwrap();
+        let extras = SyncArbiter::start(1, move || {
+            NativeCapabilityHost::new()
+        });
+        let init = crate::capability::native_host::Initialize{
+            cap,
+            mw_chain: vec![],
+            seed,
+            image_ref: None
+        };
+        let _ = extras.send(init).await.unwrap();
+
+        let req = GeneratorRequest {
+            guid: true,
+            sequence: false,
+            random: false,
+            min: 0,
+            max: 0,
+        };
+        let inv = Invocation::new(
+            &kp,
+            WasccEntity::Actor(SYSTEM_ACTOR.to_string()),
+            WasccEntity::Capability {
+                id: "VDHPKGFKDI34Y4RN4PWWZHRYZ6373HYRSNNEM4UTDLLOGO5B37TSVREP".to_string(),
+                contract_id: "wascc:extras".to_string(),
+                binding: "default".to_string(),
+            },
+            OP_REQUEST_GUID,
+            crate::generated::extras::serialize(&req).unwrap(),
+        );
+        let ir = extras.send(inv).await.unwrap();
+        assert!(ir.error.is_none());
+        let gen_r: GeneratorResult = crate::generated::extras::deserialize(&ir.msg).unwrap();
+        assert!(gen_r.guid.is_some());
+    }
 }
 
 fn extrude(
@@ -111,185 +313,5 @@ fn get_descriptor(plugin: &Box<dyn CapabilityProvider>) -> Result<CapabilityDesc
         }
     } else {
         Err("Failed to invoke GetCapabilityDescriptor".into())
-    }
-}
-
-impl Actor for NativeCapabilityHost {
-    type Context = SyncContext<Self>;
-
-    fn started(&mut self, ctx: &mut Self::Context) {
-        let b = MessageBus::from_registry();
-        let entity = WasccEntity::Capability {
-            id: self.cap.claims.subject.to_string(),
-            contract_id: self.descriptor.id.to_string(),
-            binding: self.cap.binding_name.to_string(),
-        };
-        info!("Native provider started: {}", entity.url());
-        let nativedispatch = ProviderDispatcher::new(
-            b.clone().recipient(),
-            KeyPair::from_seed(&self.kp.seed().unwrap()).unwrap(),
-            entity.clone(),
-        );
-        if let Err(e) = self.plugin.configure_dispatch(Box::new(nativedispatch)) {
-            error!(
-                "Failed to configure provider dispatcher: {}, provider stopping.",
-                e
-            );
-            ctx.stop();
-        }
-        let url = entity.url().to_string();
-        let _ = block_on(async move {
-            if let Err(e) = b
-                .send(Subscribe {
-                    interest: entity.clone(),
-                    subscriber: ctx.address().recipient(),
-                })
-                .await
-            {
-                error!(
-                    "Native capability provider failed to subscribe to bus: {}",
-                    e
-                );
-                ctx.stop();
-            }
-        });
-        let cp = ControlPlane::from_registry();
-        cp.do_send(PublishEvent {
-            event: ControlEvent::ProviderStarted {
-                header: Default::default(),
-                binding_name: self.cap.binding_name.to_string(),
-                provider_id: self.cap.claims.subject.to_string(),
-                contract_id: self.descriptor.id.to_string(),
-                image_ref: self.image_ref.clone(),
-            },
-        });
-        info!("Native Capability Provider '{}' ready", url);
-    }
-
-    fn stopped(&mut self, _ctx: &mut Self::Context) {
-        info!(
-            "Provider stopped {} - {}",
-            &self.cap.claims.subject, self.descriptor.name
-        );
-
-        let cp = ControlPlane::from_registry();
-        cp.do_send(PublishEvent {
-            event: ControlEvent::ProviderStopped {
-                header: Default::default(),
-                binding_name: self.cap.binding_name.to_string(),
-                provider_id: self.cap.claims.subject.to_string(),
-                contract_id: self.descriptor.id.to_string(),
-                reason: TerminationReason::Requested,
-            },
-        });
-        self.plugin.stop(); // Tell the provider to clean up, dispose of resources, stop threads, etc
-    }
-}
-
-impl Handler<Invocation> for NativeCapabilityHost {
-    type Result = InvocationResponse;
-
-    /// Receives an invocation from any source, validating the anti-forgery token
-    /// and that the destination matches this process. If those checks pass, runs
-    /// the capability provider pre-invoke middleware, invokes the operation on the native
-    /// plugin, then runs the provider post-invoke middleware.
-    fn handle(&mut self, inv: Invocation, ctx: &mut Self::Context) -> Self::Result {
-        trace!(
-            "Provider {} handling {}",
-            self.cap.claims.subject,
-            inv.operation
-        );
-        if let WasccEntity::Actor(ref s) = inv.origin {
-            if let WasccEntity::Capability {
-                id,
-                contract_id,
-                binding,
-            } = &inv.target
-            {
-                if id != &self.cap.id() {
-                    return InvocationResponse::error(
-                        &inv,
-                        "Invocation target ID did not match provider ID",
-                    );
-                }
-                if let Err(e) = run_capability_pre_invoke(&inv, &self.mw_chain) {
-                    return InvocationResponse::error(
-                        &inv,
-                        &format!("Capability middleware pre-invoke failure: {}", e),
-                    );
-                }
-
-                match self.plugin.handle_call(&s, &inv.operation, &inv.msg) {
-                    Ok(msg) => {
-                        let ir = InvocationResponse::success(&inv, msg);
-                        match run_capability_post_invoke(ir, &self.mw_chain) {
-                            Ok(r) => r,
-                            Err(e) => InvocationResponse::error(
-                                &inv,
-                                &format!("Capability middleware post-invoke failure: {}", e),
-                            ),
-                        }
-                    }
-                    Err(e) => InvocationResponse::error(&inv, &format!("{}", e)),
-                }
-            } else {
-                InvocationResponse::error(&inv, "Invocation sent to the wrong target")
-            }
-        } else {
-            InvocationResponse::error(&inv, "Attempt to invoke capability from non-actor origin")
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crate::capability::extras::{ExtrasCapabilityProvider, OP_REQUEST_GUID};
-    use crate::capability::native::NativeCapability;
-    use crate::capability::native_host::{NativeCapabilityHost, NativeCapabilityHostBuilder};
-    use crate::dispatch::{Invocation, InvocationResponse, WasccEntity};
-    use crate::generated::extras::{GeneratorRequest, GeneratorResult};
-    use crate::Result;
-    use crate::SYSTEM_ACTOR;
-    use actix::prelude::*;
-    use std::sync::Arc;
-    use wascap::prelude::KeyPair;
-
-    #[actix_rt::test]
-    async fn test_extras_actor() {
-        let kp = KeyPair::new_server();
-        let seed = kp.seed().unwrap();
-        let extras = SyncArbiter::start(1, move || {
-            let key = KeyPair::from_seed(&seed).unwrap();
-            let extras = ExtrasCapabilityProvider::default();
-            let claims = crate::capability::extras::get_claims();
-            let cap = NativeCapability::from_instance(extras, Some("default".to_string()), claims)
-                .unwrap();
-            NativeCapabilityHostBuilder::try_new(cap, vec![], None)
-                .unwrap()
-                .build(key)
-        });
-
-        let req = GeneratorRequest {
-            guid: true,
-            sequence: false,
-            random: false,
-            min: 0,
-            max: 0,
-        };
-        let inv = Invocation::new(
-            &kp,
-            WasccEntity::Actor(SYSTEM_ACTOR.to_string()),
-            WasccEntity::Capability {
-                id: "VDHPKGFKDI34Y4RN4PWWZHRYZ6373HYRSNNEM4UTDLLOGO5B37TSVREP".to_string(),
-                contract_id: "wascc:extras".to_string(),
-                binding: "default".to_string(),
-            },
-            OP_REQUEST_GUID,
-            crate::generated::extras::serialize(&req).unwrap(),
-        );
-        let ir = extras.send(inv).await.unwrap();
-        assert!(ir.error.is_none());
-        let gen_r: GeneratorResult = crate::generated::extras::deserialize(&ir.msg).unwrap();
-        assert!(gen_r.guid.is_some());
     }
 }

--- a/crates/wascc-host/src/capability/native_host.rs
+++ b/crates/wascc-host/src/capability/native_host.rs
@@ -232,16 +232,14 @@ mod test {
         let key = KeyPair::from_seed(&seed).unwrap();
         let extras = ExtrasCapabilityProvider::default();
         let claims = crate::capability::extras::get_claims();
-        let cap = NativeCapability::from_instance(extras, Some("default".to_string()), claims)
-            .unwrap();
-        let extras = SyncArbiter::start(1, move || {
-            NativeCapabilityHost::new()
-        });
-        let init = crate::capability::native_host::Initialize{
+        let cap =
+            NativeCapability::from_instance(extras, Some("default".to_string()), claims).unwrap();
+        let extras = SyncArbiter::start(1, move || NativeCapabilityHost::new());
+        let init = crate::capability::native_host::Initialize {
             cap,
             mw_chain: vec![],
             seed,
-            image_ref: None
+            image_ref: None,
         };
         let _ = extras.send(init).await.unwrap();
 

--- a/crates/wascc-host/src/capability/native_host.rs
+++ b/crates/wascc-host/src/capability/native_host.rs
@@ -63,7 +63,6 @@ impl Actor for NativeCapabilityHost {
         let cp = ControlPlane::from_registry();
         cp.do_send(PublishEvent {
             event: ControlEvent::ProviderStopped {
-                header: Default::default(),
                 binding_name: state.cap.binding_name.to_string(),
                 provider_id: state.cap.claims.subject.to_string(),
                 contract_id: state.descriptor.id.to_string(),
@@ -143,7 +142,6 @@ impl Handler<Initialize> for NativeCapabilityHost {
         let cp = ControlPlane::from_registry();
         cp.do_send(PublishEvent {
             event: ControlEvent::ProviderStarted {
-                header: Default::default(),
                 binding_name: state.cap.binding_name.to_string(),
                 provider_id: state.cap.claims.subject.to_string(),
                 contract_id: state.descriptor.id.to_string(),

--- a/crates/wascc-host/src/control_plane/mod.rs
+++ b/crates/wascc-host/src/control_plane/mod.rs
@@ -1,5 +1,5 @@
 use crate::control_plane::cpactor::ControlPlane;
-use crate::control_plane::events::ControlEvent;
+use crate::control_plane::events::{ControlEvent, PublishedEvent};
 use crate::messagebus::MessageBus;
 use crate::Result;
 use actix::Addr;
@@ -12,12 +12,18 @@ pub mod events;
 /// necessary to provide an entrypoint into the functionality exposed via the ControlInterface
 /// struct, which is supplied to the control plane provider during the init function.
 pub trait ControlPlaneProvider: Sync + Send {
+    /// Used to initialize the control plane provider. Use this function to establish whatever connections
+    /// and resources are needed
     fn init(&mut self, controller: ControlInterface) -> Result<()>;
+    /// Invoked when the host is about to stop to give the provider time to clean up
     fn close(&mut self) -> Result<()>;
-    fn emit_control_event(&self, event: ControlEvent) -> Result<()>;
+    /// Instructs the control plane provider to emit a control plane event. This event
+    /// contains a header and the raw event, which should be enough information to allow
+    /// the provider to construct a `CloudEvents` event, for example
+    fn emit_control_event(&self, event: PublishedEvent) -> Result<()>;
 }
 
-/// The control interface is given out to a struct that implements the ControlPlaneProvider
+/// The control interface is given out to an instance that implements the ControlPlaneProvider
 /// interface. This "handle" is used to give the control plane provider access to control
 /// functionality without knowledge of the host internals.
 #[derive(Clone)]

--- a/crates/wascc-host/src/host.rs
+++ b/crates/wascc-host/src/host.rs
@@ -141,7 +141,6 @@ impl Host {
             .send(PublishEvent {
                 event: ControlEvent::HostStopped {
                     reason: TerminationReason::Requested,
-                    header: Default::default(),
                 },
             })
             .await;

--- a/crates/wascc-host/src/messagebus/hb.rs
+++ b/crates/wascc-host/src/messagebus/hb.rs
@@ -43,7 +43,6 @@ async fn generate_heartbeat_event(
     seed: String,
 ) -> ControlEvent {
     ControlEvent::Heartbeat {
-        header: Default::default(),
         claims: claims,
         entities: healthping_subscribers(&entities, seed).await,
     }


### PR DESCRIPTION
After talking to the people who actually know what they're doing in the Actix gitter/discord, I found that I was using a bit of an anti-pattern. It should be impossible for an actor to fail to start, and there were a couple of places, especially in the capability provider host actor, where I was pulling shenanigans like `try_new()`, which I then hid behind a builder (that also returned a result).

Instead, the recommended practice is that all actors should be 100% guaranteed to start, and if you need to set an initial state that could be rejected or invalid, then you do so through sending that message to the actor, and the actor stops itself if there's an error.

So far I've only refactored the host controller's interaction with the native capability provider host. After we agree on the cleanest way to implement this, I can poke around the rest of all the actors and make them conform to this new pattern.